### PR TITLE
use variable interpolation for the environment

### DIFF
--- a/deploy/postgres.docker-compose.yaml
+++ b/deploy/postgres.docker-compose.yaml
@@ -9,18 +9,18 @@ services:
       # If you use selinux it might be necessary to add the :Z after the volume
       # - media:/home/nonroot/pdfding/media:Z
     environment:
-      DEFAULT_THEME: dark
-      DEFAULT_THEME_COLOR: blue
+      - DEFAULT_THEME=${DEFAULT_THEME:-dark}
+      - DEFAULT_THEME_COLOR=${DEFAULT_THEME_COLOR:-blue}
       # use a long random secret
-      SECRET_KEY: some_secret
+      - SECRET_KEY=${SECRET_KEY:-some_secret}
       # the domain where you want to access PdfDing, e.g. pdfding.com
-      HOST_NAME: 127.0.0.1
-      DATABASE_TYPE: POSTGRES
-      POSTGRES_PASSWORD: pdfding
-      POSTGRES_HOST: postgres
+      - HOST_NAME=${HOST_NAME:-127.0.0.1}
+      - DATABASE_TYPE=${DATABASE_TYPE:-POSTGRES}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pdfding}
+      - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
       # In production set the following values to True
-      CSRF_COOKIE_SECURE: 'FALSE'
-      SESSION_COOKIE_SECURE: 'FALSE'
+      - CSRF_COOKIE_SECURE=${CSRF_COOKIE_SECURE:-'FALSE'}
+      - SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-'FALSE'}
     ports:
       - "8000:8000"
 
@@ -29,10 +29,10 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:
-      POSTGRES_DB: pdfding
-      POSTGRES_USER: pdfding
-      POSTGRES_PASSWORD: pdfding
-      POSTGRES_PORT: 5432
+      - POSTGRES_DB=pdfding
+      - POSTGRES_USER=pdfding
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pdfding}
+      - POSTGRES_PORT=5432
 
 volumes:
   media:

--- a/deploy/sqlite.docker-compose.yaml
+++ b/deploy/sqlite.docker-compose.yaml
@@ -11,15 +11,15 @@ services:
       # - sqlite_data:/home/nonroot/pdfding/db:Z
       # - media:/home/nonroot/pdfding/media:Z
     environment:
-      DEFAULT_THEME: dark
-      DEFAULT_THEME_COLOR: blue
+      - DEFAULT_THEME=${DEFAULT_THEME:-dark}
+      - DEFAULT_THEME_COLOR=${DEFAULT_THEME_COLOR:-blue}
       # use a long random secret
-      SECRET_KEY: some_secret
+      - SECRET_KEY=${SECRET_KEY:-some_secret}
       # the domain where you want to access PdfDing, e.g. pdfding.com
-      HOST_NAME: 127.0.0.1
+      - HOST_NAME=${HOST_NAME:-127.0.0.1}
       # In production set the following values to True
-      CSRF_COOKIE_SECURE: 'FALSE'
-      SESSION_COOKIE_SECURE: 'FALSE'
+      - CSRF_COOKIE_SECURE=${CSRF_COOKIE_SECURE:-'FALSE'}
+      - SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-'FALSE'}
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
this allows you to pass a .env file with these environment variables inside, in the `docker compose up` command.

Example:

```console
$ cat .env
HOST_NAME=10.10.100.12
POSTGRES_PASSWORD=my_super_secure_password
DEFAULT_THEME_COLOR=green
CSRF_COOKIE_SECURE=True
SESSION_COOKIE_SECURE=True
SECRET_KEY=wowowowowowow
$ docker compose -f postgres.docker-compose.yaml --env-file .env up -d
```