### PR TITLE
Remove unnecessary apk update command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,7 @@ ARG USERNAME=nonroot
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-RUN apk update \
-    && apk add --no-cache libmagic netcat-openbsd \
+RUN apk add --no-cache libmagic netcat-openbsd \
     && addgroup -g $USER_GID  $USERNAME \
     && adduser -G $USERNAME -u $USER_UID  $USERNAME -D
 


### PR DESCRIPTION
The `apk add` commands already include the `--no-cache` option, eliminating the need for a separate update step. This approach ensures the latest packages are installed without creating a local cache. Including an additional `apk update`  would only increase the image size without providing any benefits.