### PR TITLE
Load additional results without changing pages in the overviews

### DIFF
--- a/pdfding/admin/templates/includes/user_overview_page.html
+++ b/pdfding/admin/templates/includes/user_overview_page.html
@@ -1,0 +1,14 @@
+{% for user in page_obj %}
+{% widthratio current_page|add:-1 1 items_per_page as loop_offset %}
+{% with loop_id=forloop.counter|add:loop_offset %}
+<div class="border rounded-md bg-slate-100 border-slate-300 hover:border-slate-400
+            dark:bg-slate-800 dark:border-slate-700 dark:hover:border-slate-600
+            creme:bg-creme-dark-light creme:border-creme-dark creme:hover:border-stone-400">
+    <div class="px-3 md:px-5 py-1">
+        {% include 'includes/user.html' %}
+    </div>
+</div>
+{% endwith %}
+{% endfor %}
+
+{% include 'includes/get_next_page.html' with get_next_overview_page_name='get_next_user_overview_page' %}

--- a/pdfding/admin/templates/user_overview.html
+++ b/pdfding/admin/templates/user_overview.html
@@ -17,17 +17,7 @@
                     <span class="pt-4 text-lg">Please try a different search.</span>
                 </div>
                 {% else %}
-                {% for user in page_obj %}
-                {% with loop_id=forloop.counter %}
-                <div class="border rounded-md bg-slate-100 border-slate-300 hover:border-slate-400
-                            dark:bg-slate-800 dark:border-slate-700 dark:hover:border-slate-600
-                            creme:bg-creme-dark-light creme:border-creme-dark creme:hover:border-stone-400">
-                    <div class="px-3 md:px-5 py-1">
-                        {% include 'includes/user.html' %}
-                    </div>
-                </div>
-                {% endwith %}
-                {% endfor %}
+                {% include 'includes/user_overview_page.html' %}
                 {% endif %}
             </div>
         </div>

--- a/pdfding/admin/urls.py
+++ b/pdfding/admin/urls.py
@@ -5,7 +5,7 @@ urlpatterns = [
     path('users', views.Overview.as_view(), name='user_overview'),
     path('info', views.Information.as_view(), name='instance_info'),
     path('query/', views.OverviewQuery.as_view(), name='user_overview_query'),
-    path('<int:page>/', views.Overview.as_view(), name='user_overview_page'),
+    path('get_next_overview_page/<int:page>/', views.Overview.as_view(), name='get_next_user_overview_page'),
     path('rights/<identifier>', views.AdjustAdminRights.as_view(), name='admin_adjust_rights'),
     path('delete/<identifier>', views.DeleteProfile.as_view(), name='admin_delete_profile'),
 ]

--- a/pdfding/admin/views.py
+++ b/pdfding/admin/views.py
@@ -25,6 +25,8 @@ class BaseAdminMixin:
 
 
 class OverviewMixin(BaseAdminMixin):
+    overview_page_name = 'user_overview_page'
+
     @staticmethod
     def get_sorting(request: HttpRequest):
         """Get the sorting of the overview page."""

--- a/pdfding/base/tests/base_view_definitions.py
+++ b/pdfding/base/tests/base_view_definitions.py
@@ -28,6 +28,8 @@ class BaseAddMixin(BaseMixin):
 
 
 class OverviewMixin(BaseMixin):
+    overview_page_name = 'pdf_overview/overview_page'
+
     @staticmethod
     def get_sorting(request: HttpRequest):
         """Get the sorting of the overview page."""

--- a/pdfding/core/settings/base.py
+++ b/pdfding/core/settings/base.py
@@ -151,7 +151,6 @@ TIME_ZONE = 'UTC'
 USE_I18N = True
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
@@ -164,6 +163,9 @@ MEDIA_ROOT = BASE_DIR / 'media'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
+
+# number of items of overview paginations
+ITEMS_PER_PAGE = 15
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 

--- a/pdfding/e2e/test_admin_e2e.py
+++ b/pdfding/e2e/test_admin_e2e.py
@@ -71,6 +71,23 @@ class AdminE2ETestCase(PdfDingE2ETestCase):
 
         self.assertEqual(changed_user.profile.user_sorting, Profile.UserSortingChoice.EMAIL_ASC)
 
+    def test_load_next_page(self):
+        self.user.profile.user_sorting = Profile.UserSortingChoice.OLDEST
+        self.user.profile.save()
+
+        for i in range(4, 17):
+            User.objects.create_user(username=i, password="password", email=f"{i}@a.com")
+
+        with sync_playwright() as p:
+            self.open(reverse('user_overview'), p)
+            expect(self.page.locator("#user-15")).to_be_visible()
+            expect(self.page.locator("#user-16")).not_to_be_visible()
+
+            self.page.locator("#next_page_1_toggle").click()
+            expect(self.page.locator("#user-16")).to_be_visible()
+            expect(self.page.locator("#user-16")).to_contain_text('15@a.com')
+            expect(self.page.locator("#next_page_2_toggle")).not_to_be_visible()
+
     @patch('admin.views.get_latest_version', return_value='0.0.0')
     def test_new_version_available(self, mock_get_latest_version):
         with sync_playwright() as p:

--- a/pdfding/e2e/test_pdf_e2e.py
+++ b/pdfding/e2e/test_pdf_e2e.py
@@ -269,6 +269,23 @@ class PdfOverviewE2ETestCase(PdfDingE2ETestCase):
             if i % 5 == 1:
                 pdf.tags.set([tag])
 
+    def test_load_next_page(self):
+        self.user.profile.pdf_sorting = Profile.PdfSortingChoice.OLDEST
+        self.user.profile.save()
+
+        Pdf.objects.create(owner=self.user.profile, name='page_1_pdf')
+        Pdf.objects.create(owner=self.user.profile, name='page_2_pdf')
+
+        with sync_playwright() as p:
+            self.open(reverse('pdf_overview'), p)
+            expect(self.page.locator("#pdf-15")).to_be_visible()
+            expect(self.page.locator("#pdf-16")).not_to_be_visible()
+
+            self.page.locator("#next_page_1_toggle").click()
+            expect(self.page.locator("#pdf-16")).to_be_visible()
+            expect(self.page.locator("#pdf-16")).to_contain_text('page_2_pdf')
+            expect(self.page.locator("#next_page_2_toggle")).not_to_be_visible()
+
     # def test_thumbnails_on(self):
     #     self.user.profile.show_thumbnails = 'Enabled'
     #     self.user.profile.save()

--- a/pdfding/e2e/test_share_e2e.py
+++ b/pdfding/e2e/test_share_e2e.py
@@ -78,6 +78,23 @@ class SharedPdfE2ETestCase(PdfDingE2ETestCase):
 
         self.assertEqual(changed_user.profile.shared_pdf_sorting, Profile.SharedPdfSortingChoice.NAME_ASC)
 
+    def test_load_next_page(self):
+        self.user.profile.shared_pdf_sorting = Profile.SharedPdfSortingChoice.OLDEST
+        self.user.profile.save()
+
+        for i in range(17):
+            SharedPdf.objects.create(owner=self.user.profile, name=f'shared_{i}', pdf=self.pdf)
+
+        with sync_playwright() as p:
+            self.open(reverse('shared_pdf_overview'), p)
+            expect(self.page.locator("#shared-pdf-15")).to_be_visible()
+            expect(self.page.locator("#shared-pdf-16")).not_to_be_visible()
+
+            self.page.locator("#next_page_1_toggle").click()
+            expect(self.page.locator("#shared-pdf-16")).to_be_visible()
+            expect(self.page.locator("#shared-pdf-16")).to_contain_text('shared_15')
+            expect(self.page.locator("#next_page_2_toggle")).not_to_be_visible()
+
     def test_delete(self):
         SharedPdf.objects.create(owner=self.user.profile, name='some_shared_pdf', pdf=self.pdf)
 

--- a/pdfding/pdf/templates/includes/pdf_overview/overview_page.html
+++ b/pdfding/pdf/templates/includes/pdf_overview/overview_page.html
@@ -1,0 +1,28 @@
+{% for pdf in page_obj %}
+{% widthratio current_page|add:-1 1 items_per_page as loop_offset %}
+{% with loop_id=forloop.counter|add:loop_offset %}
+<div id="pdf-{{ loop_id }}" class="border rounded-md bg-slate-100 border-slate-300 hover:border-slate-400
+            dark:bg-slate-800 dark:border-slate-700 dark:hover:border-slate-600
+            creme:bg-creme-dark-light creme:border-creme-dark creme:hover:border-stone-400">
+    <div class="px-3 md:px-5 py-1">
+        {% if 1 %}
+        {% include 'includes/pdf_overview/compact_pdf.html' %}
+        {% endif %}
+    </div>
+    {% if pdf.number_of_pages > 0 %}
+    <div class="hover:cursor-pointer pt-1 -mt-1!" x-data="{ tooltip_progress: false }" id="progressbar-{{ loop_id }}">
+            <div x-on:mouseenter="tooltip_progress = true" x-on:mouseleave="tooltip_progress = false"
+                 class="w-full h-1 rounded-sm">
+                <div style="width: {{ pdf.progress }}%;" class="h-1 bg-primary! rounded-sm"></div>
+            </div>
+            <span x-show="tooltip_progress" x-transition:enter.duration.500ms x-cloak
+                class="z-50 absolute bg-primary text-gray-100 text-sm rounded-xs p-2 mt-1">
+             {{ pdf.progress }}% - Page {{ pdf.current_page_for_progress }} of {{ pdf.number_of_pages }}
+            </span>
+    </div>
+    {% endif %}
+</div>
+{% endwith %}
+{% endfor %}
+
+{% include 'includes/get_next_page.html' with get_next_overview_page_name='get_next_pdf_overview_page' %}

--- a/pdfding/pdf/templates/includes/shared_overview/overview_page.html
+++ b/pdfding/pdf/templates/includes/shared_overview/overview_page.html
@@ -1,0 +1,14 @@
+{% for shared_pdf in page_obj %}
+{% widthratio current_page|add:-1 1 items_per_page as loop_offset %}
+{% with loop_id=forloop.counter|add:loop_offset %}
+<div id="shared-pdf-{{ loop_id }}" class="border rounded-md bg-slate-100 border-slate-300 hover:border-slate-400
+            dark:bg-slate-800 dark:border-slate-700 dark:hover:border-slate-600
+            creme:bg-creme-dark-light creme:border-creme-dark creme:hover:border-stone-400">
+    <div class="px-3 md:px-5 py-1">
+        {% include 'includes/shared_overview/shared_pdf.html' %}
+    </div>
+</div>
+{% endwith %}
+{% endfor %}
+
+{% include 'includes/get_next_page.html' with get_next_overview_page_name='get_next_shared_overview_page' %}

--- a/pdfding/pdf/templates/pdf_overview.html
+++ b/pdfding/pdf/templates/pdf_overview.html
@@ -26,31 +26,7 @@
                     {% endif %}
                 </div>
                 {% else %}
-                {% for pdf in page_obj %}
-                {% with loop_id=forloop.counter %}
-                <div class="border rounded-md bg-slate-100 border-slate-300 hover:border-slate-400
-                            dark:bg-slate-800 dark:border-slate-700 dark:hover:border-slate-600
-                            creme:bg-creme-dark-light creme:border-creme-dark creme:hover:border-stone-400">
-                    <div class="px-3 md:px-5 py-1">
-                        {% if 1 %}
-                        {% include 'includes/pdf_overview/compact_pdf.html' %}
-                        {% endif %}
-                    </div>
-                    {% if pdf.number_of_pages > 0 %}
-                    <div class="hover:cursor-pointer pt-1 -mt-1!" x-data="{ tooltip_progress: false }" id="progressbar-{{ loop_id }}">
-                            <div x-on:mouseenter="tooltip_progress = true" x-on:mouseleave="tooltip_progress = false"
-                                 class="w-full h-1 rounded-sm">
-                                <div style="width: {{ pdf.progress }}%;" class="h-1 bg-primary! rounded-sm"></div>
-                            </div>
-                            <span x-show="tooltip_progress" x-transition:enter.duration.500ms x-cloak
-                                class="z-50 absolute bg-primary text-gray-100 text-sm rounded-xs p-2 mt-1">
-                             {{ pdf.progress }}% - Page {{ pdf.current_page_for_progress }} of {{ pdf.number_of_pages }}
-                            </span>
-                    </div>
-                    {% endif %}
-                </div>
-                {% endwith %}
-                {% endfor %}
+                {% include 'includes/pdf_overview/overview_page.html' %}
                 {% endif %}
             </div>
         </div>

--- a/pdfding/pdf/templates/shared_pdf_overview.html
+++ b/pdfding/pdf/templates/shared_pdf_overview.html
@@ -13,17 +13,7 @@
                     <span class="text-2xl">You have not shared any PDFs yet</span>
                 </div>
                 {% else %}
-                {% for shared_pdf in page_obj %}
-                {% with loop_id=forloop.counter %}
-                <div class="border rounded-md bg-slate-100 border-slate-300 hover:border-slate-400
-                            dark:bg-slate-800 dark:border-slate-700 dark:hover:border-slate-600
-                            creme:bg-creme-dark-light creme:border-creme-dark creme:hover:border-stone-400">
-                    <div class="px-3 md:px-5 py-1">
-                        {% include 'includes/shared_overview/shared_pdf.html' %}
-                    </div>
-                </div>
-                {% endwith %}
-                {% endfor %}
+                {% include 'includes/shared_overview/overview_page.html' %}
                 {% endif %}
             </div>
         </div>

--- a/pdfding/pdf/urls.py
+++ b/pdfding/pdf/urls.py
@@ -5,7 +5,7 @@ from django.urls import path
 urlpatterns = [
     path('', pdf_views.Overview.as_view(), name='pdf_overview'),
     path('query/', pdf_views.OverviewQuery.as_view(), name='pdf_overview_query'),
-    path('<int:page>/', pdf_views.Overview.as_view(), name='pdf_overview_page'),
+    path('get_next_overview_page/<int:page>/', pdf_views.Overview.as_view(), name='get_next_pdf_overview_page'),
     path('add', pdf_views.Add.as_view(), name='add_pdf'),
     path('bulk_add', pdf_views.BulkAdd.as_view(), name='bulk_add_pdfs'),
     path('delete/<identifier>', pdf_views.Delete.as_view(), name='delete_pdf'),
@@ -22,6 +22,11 @@ urlpatterns = [
     path('view/<identifier>', pdf_views.ViewerView.as_view(), name='view_pdf'),
     path('share/<identifier>', share_views.Share.as_view(), name='share_pdf'),
     path('shared/overview/', share_views.Overview.as_view(), name='shared_pdf_overview'),
+    path(
+        'shared/get_next_overview_page/<int:page>/',
+        share_views.Overview.as_view(),
+        name='get_next_shared_overview_page',
+    ),
     path('shared/overview/query/', share_views.OverviewQuery.as_view(), name='shared_pdf_overview_query'),
     path('shared/overview/<int:page>/', share_views.Overview.as_view(), name='shared_pdf_overview_page'),
     path('shared/delete/<identifier>', share_views.Delete.as_view(), name='delete_shared_pdf'),

--- a/pdfding/pdf/views/pdf_views.py
+++ b/pdfding/pdf/views/pdf_views.py
@@ -120,6 +120,8 @@ class BulkAddPdfMixin(BasePdfMixin):
 
 
 class OverviewMixin(BasePdfMixin):
+    overview_page_name = 'pdf_overview/overview_page'
+
     @staticmethod
     def get_sorting(request: HttpRequest):
         """Get the sorting of the overview page."""

--- a/pdfding/pdf/views/share_views.py
+++ b/pdfding/pdf/views/share_views.py
@@ -99,6 +99,8 @@ class AddSharedPdfMixin(BaseShareMixin):
 
 
 class OverviewMixin(BaseShareMixin):
+    overview_page_name = 'shared_overview/overview_page'
+
     @staticmethod
     def get_sorting(request: HttpRequest):
         """Get the sorting of the overview page."""

--- a/pdfding/static/css/input.css
+++ b/pdfding/static/css/input.css
@@ -158,14 +158,14 @@ label {
 }
 input[type=file] {
     @apply  w-full text-gray-400 dark:text-slate-200 bg-gray-100 dark:bg-slate-600 creme:text-stone-700 creme:bg-creme-light file:cursor-pointer
-    cursor-pointer file:border-0 file:py-4 file:px-4 file:-my-7 file:-ml-5 file:mr-4 file:bg-primary
+    cursor-pointer file:border-0 file:py-3 file:px-4 file:-my-7 file:-ml-5 file:mr-4 file:bg-primary
     file:hover:bg-secondary file:text-white file:font-bold file:rounded-lg
 }
 input[type=checkbox] {
     @apply  accent-primary
 }
 .textarea, textarea, input {
-    @apply w-full rounded-lg py-4 px-5 bg-gray-100 dark:bg-slate-600 creme:bg-creme-dark-light creme:text-stone-700
+    @apply w-full rounded-lg py-3 px-5 bg-gray-100 dark:bg-slate-600 creme:bg-creme-dark-light creme:text-stone-700
 }
 .textarea:focus, textarea:focus, input:focus {
     @apply outline outline-1 outline-primary

--- a/pdfding/templates/includes/get_next_page.html
+++ b/pdfding/templates/includes/get_next_page.html
@@ -1,0 +1,51 @@
+<div id="next_page_{{ current_page }}"
+     x-data="{ in_progress: false }"
+     class="flex justify-center items-center gap-x-1 font-semibold
+            text-slate-500 dark:text-slate-400 creme:text-stone-500
+            [&>div>div]:flex [&>div>div]:flex-row [&>div>div]:items-center [&>div>div]:gap-x-1">
+    {% if next_page_available %}
+    <div id="next_page_{{ current_page }}_toggle">
+        <div class="cursor-pointer hover:text-slate-900 dark:hover:text-slate-100 creme:hover:text-stone-700"
+             x-show="!in_progress"
+             @click="in_progress = true"
+             hx-get="{% url get_next_overview_page_name page=current_page|add:1 %}"
+             hx-target="#next_page_{{ current_page }}"
+             hx-swap="outerHTML">
+            <a>Load More</a>
+            <svg class="w-5 h-5 -rotate-90!"
+                 fill="currentColor" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400.004 400.004" xml:space="preserve">
+                <!-- source: https://www.svgrepo.com/svg/97894/left-arrow -->
+                <!-- license: CC0 License-->
+                <path d="M382.688,182.686H59.116l77.209-77.214c6.764-6.76,6.764-17.726,0-24.485c-6.764-6.764-17.73-6.764-24.484,0L5.073,187.757
+                    c-6.764,6.76-6.764,17.727,0,24.485l106.768,106.775c3.381,3.383,7.812,5.072,12.242,5.072c4.43,0,8.861-1.689,12.242-5.072
+                    c6.764-6.76,6.764-17.726,0-24.484l-77.209-77.218h323.572c9.562,0,17.316-7.753,17.316-17.315
+                    C400.004,190.438,392.251,182.686,382.688,182.686z"/>
+            </svg>
+        </div>
+        <svg x-show="in_progress" x-cloak
+             class="animate-spin -ml-1 mr-3 h-5 w-5 text-slate-800 dark:text-slate-200 creme:text-stone-700"
+             xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+    </div>
+    <span x-show="!in_progress" class="cursor-default mb-1 pl-1 pr-2">|</span>
+    {% endif %}
+    <div>
+        <div x-show="!in_progress"
+             class="cursor-pointer hover:text-slate-900 dark:hover:text-slate-100 creme:hover:text-stone-700"
+             @click="window.scrollTo({top: 0, behavior: 'smooth'})">
+            <a>Back to Top</a>
+            <svg x-show="!in_progress"
+                 class="w-5 h-5 rotate-90!"
+                 fill="currentColor" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400.004 400.004" xml:space="preserve">
+                <!-- source: https://www.svgrepo.com/svg/97894/left-arrow -->
+                <!-- license: CC0 License-->
+                <path d="M382.688,182.686H59.116l77.209-77.214c6.764-6.76,6.764-17.726,0-24.485c-6.764-6.764-17.73-6.764-24.484,0L5.073,187.757
+                    c-6.764,6.76-6.764,17.727,0,24.485l106.768,106.775c3.381,3.383,7.812,5.072,12.242,5.072c4.43,0,8.861-1.689,12.242-5.072
+                    c6.764-6.76,6.764-17.726,0-24.484l-77.209-77.218h323.572c9.562,0,17.316-7.753,17.316-17.315
+                    C400.004,190.438,392.251,182.686,382.688,182.686z"/>
+            </svg>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
In the overviews there is now a load more button for appending the objects of the next page to the end of the current page. Previously, users needed to switch pages via next and previous buttons. Furthermore, there is now also a go to top button.

closes #95 