### PR TITLE
PDF overview fixes / Add progress bar setting

### DIFF
--- a/pdfding/base/base_views.py
+++ b/pdfding/base/base_views.py
@@ -44,34 +44,21 @@ class BaseOverview(View):
         Display the overview.
         """
 
+        sorting = self.get_sorting(request)
+        page_object, next_page_available = self.get_page_objects(request, sorting, page, items_per_page)
+        context = {
+            'page_obj': page_object,
+            'sorting': sorting,
+            'items_per_page': items_per_page,
+            'next_page_available': next_page_available,
+            'current_page': page,
+        }
+
+        context |= self.get_extra_context(request)
+
         if request.htmx:
-            sorting = self.get_sorting(request)
-            page_object, next_page_available = self.get_page_objects(request, sorting, page, items_per_page)
-
-            return render(
-                request,
-                f'includes/{self.overview_page_name}.html',
-                context={
-                    'page_obj': page_object,
-                    'items_per_page': items_per_page,
-                    'next_page_available': next_page_available,
-                    'current_page': page,
-                },
-            )
+            return render(request, f'includes/{self.overview_page_name}.html', context)
         else:
-            sorting = self.get_sorting(request)
-            page_object, next_page_available = self.get_page_objects(request, sorting, page, items_per_page)
-
-            context = {
-                'page_obj': page_object,
-                'sorting': sorting,
-                'current_page': 1,
-                'items_per_page': items_per_page,
-                'next_page_available': next_page_available,
-            }
-
-            context |= self.get_extra_context(request)
-
             return render(request, f'{self.obj_name}_overview.html', context)
 
     def get_page_objects(self, request: HttpRequest, sorting: str, page: int, items_per_page: int):

--- a/pdfding/base/tests/test_base_views.py
+++ b/pdfding/base/tests/test_base_views.py
@@ -118,9 +118,11 @@ class TestViews(TestCase):
 
         # since we are getting the second page only apple should be there and no next page
         self.assertEqual(pdf_names, ['Apple'])
+        self.assertEqual(response.context['other'], 1234)
         self.assertEqual(response.context['next_page_available'], False)
         self.assertEqual(response.context['items_per_page'], '3')
         self.assertEqual(response.context['current_page'], '2')
+        self.assertEqual(str(response.context['sorting']), 'OrderBy(Lower(F(name)), descending=True)')
         self.assertTemplateUsed(response, 'includes/pdf_overview/overview_page.html')
 
     @override_settings(ROOT_URLCONF=__name__)

--- a/pdfding/core/settings/base.py
+++ b/pdfding/core/settings/base.py
@@ -165,7 +165,7 @@ MEDIA_ROOT = BASE_DIR / 'media'
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 # number of items of overview paginations
-ITEMS_PER_PAGE = 15
+ITEMS_PER_PAGE = 12
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 

--- a/pdfding/e2e/test_admin_e2e.py
+++ b/pdfding/e2e/test_admin_e2e.py
@@ -68,17 +68,17 @@ class AdminE2ETestCase(PdfDingE2ETestCase):
         self.user.profile.user_sorting = Profile.UserSortingChoice.OLDEST
         self.user.profile.save()
 
-        for i in range(4, 17):
+        for i in range(4, 14):
             User.objects.create_user(username=i, password="password", email=f"{i}@a.com")
 
         with sync_playwright() as p:
             self.open(reverse('user_overview'), p)
-            expect(self.page.locator("#user-15")).to_be_visible()
-            expect(self.page.locator("#user-16")).not_to_be_visible()
+            expect(self.page.locator("#user-12")).to_be_visible()
+            expect(self.page.locator("#user-13")).not_to_be_visible()
 
             self.page.locator("#next_page_1_toggle").click()
-            expect(self.page.locator("#user-16")).to_be_visible()
-            expect(self.page.locator("#user-16")).to_contain_text('15@a.com')
+            expect(self.page.locator("#user-13")).to_be_visible()
+            expect(self.page.locator("#user-13")).to_contain_text('12@a.com')
             expect(self.page.locator("#next_page_2_toggle")).not_to_be_visible()
 
     @patch('admin.views.get_latest_version', return_value='0.0.0')

--- a/pdfding/e2e/test_pdf_e2e.py
+++ b/pdfding/e2e/test_pdf_e2e.py
@@ -273,17 +273,20 @@ class PdfOverviewE2ETestCase(PdfDingE2ETestCase):
         self.user.profile.pdf_sorting = Profile.PdfSortingChoice.OLDEST
         self.user.profile.save()
 
-        Pdf.objects.create(owner=self.user.profile, name='page_1_pdf')
-        Pdf.objects.create(owner=self.user.profile, name='page_2_pdf')
+        # in set up 14 pdfs were already created
+        # other should not be shown as we'll search for pdf
+        Pdf.objects.create(owner=self.user.profile, name='other')
+        Pdf.objects.create(owner=self.user.profile, name='pdf_page_2')
 
         with sync_playwright() as p:
-            self.open(reverse('pdf_overview'), p)
-            expect(self.page.locator("#pdf-15")).to_be_visible()
-            expect(self.page.locator("#pdf-16")).not_to_be_visible()
+            self.open(f"{reverse('pdf_overview')}?search=pdf", p)
+            expect(self.page.locator("#pdf-12")).to_be_visible()
+            expect(self.page.locator("#pdf-15")).not_to_be_visible()
 
             self.page.locator("#next_page_1_toggle").click()
-            expect(self.page.locator("#pdf-16")).to_be_visible()
-            expect(self.page.locator("#pdf-16")).to_contain_text('page_2_pdf')
+            # since other is not visible #pdf-15 will contain pdf_page_2
+            expect(self.page.locator("#pdf-15")).to_be_visible()
+            expect(self.page.locator("#pdf-15")).to_contain_text('pdf_page_2')
             expect(self.page.locator("#next_page_2_toggle")).not_to_be_visible()
 
     def test_notes(self):

--- a/pdfding/e2e/test_share_e2e.py
+++ b/pdfding/e2e/test_share_e2e.py
@@ -82,17 +82,17 @@ class SharedPdfE2ETestCase(PdfDingE2ETestCase):
         self.user.profile.shared_pdf_sorting = Profile.SharedPdfSortingChoice.OLDEST
         self.user.profile.save()
 
-        for i in range(17):
+        for i in range(14):
             SharedPdf.objects.create(owner=self.user.profile, name=f'shared_{i}', pdf=self.pdf)
 
         with sync_playwright() as p:
             self.open(reverse('shared_pdf_overview'), p)
-            expect(self.page.locator("#shared-pdf-15")).to_be_visible()
-            expect(self.page.locator("#shared-pdf-16")).not_to_be_visible()
+            expect(self.page.locator("#shared-pdf-12")).to_be_visible()
+            expect(self.page.locator("#shared-pdf-13")).not_to_be_visible()
 
             self.page.locator("#next_page_1_toggle").click()
-            expect(self.page.locator("#shared-pdf-16")).to_be_visible()
-            expect(self.page.locator("#shared-pdf-16")).to_contain_text('shared_15')
+            expect(self.page.locator("#shared-pdf-13")).to_be_visible()
+            expect(self.page.locator("#shared-pdf-13")).to_contain_text('shared_12')
             expect(self.page.locator("#next_page_2_toggle")).not_to_be_visible()
 
     def test_delete(self):

--- a/pdfding/e2e/test_users_e2e.py
+++ b/pdfding/e2e/test_users_e2e.py
@@ -125,6 +125,21 @@ class UsersE2ETestCase(PdfDingE2ETestCase):
             # check inverted color mode after changing
             expect(self.page.locator("#pdf_inverted_mode")).to_contain_text("Enabled")
 
+    def test_settings_change_show_progress_bars(self):
+        with sync_playwright() as p:
+            self.open(reverse('ui_settings'), p)
+
+            # check inverted color mode before changing
+            expect(self.page.locator("#show_progress_bars")).to_contain_text("Enabled")
+
+            # change inverted color mode
+            self.page.locator("#show_progress_bars_edit").click()
+            self.page.locator("#id_show_progress_bars").select_option("Disabled")
+            self.page.get_by_role("button", name="Submit").click()
+
+            # check inverted color mode after changing
+            expect(self.page.locator("#show_progress_bars")).to_contain_text("Disabled")
+
     def test_settings_delete(self):
         with sync_playwright() as p:
             self.open(reverse('danger_settings'), p)

--- a/pdfding/pdf/service.py
+++ b/pdfding/pdf/service.py
@@ -243,7 +243,7 @@ def set_thumbnail_and_preview(
     pdf: Pdf,
     pdf_document: PdfDocument,
     desired_thumbnail_width: int = 135,
-    desired_thumbnail_width_height_ratio: float = 1 / 1.414,
+    desired_thumbnail_width_height_ratio: float = 0.77,
     desired_preview_width: int = 450,
 ):
     """Extract and set the thumbnail and the preview image of the pdf file."""

--- a/pdfding/pdf/templates/includes/pdf_overview/compact_pdf.html
+++ b/pdfding/pdf/templates/includes/pdf_overview/compact_pdf.html
@@ -1,4 +1,4 @@
-<div x-data="{ tooltip_date: false, show_notes_{{ loop_id }}: false }">
+<div x-data="{ tooltip_date: false, show_notes_{{ loop_id }}: false }" class="pb-1">
     <div class="flex flex-row justify-between text-sm relative -mb-1
                 text-slate-400 dark:text-slate-500 creme:text-stone-500">
         <div>

--- a/pdfding/pdf/templates/includes/pdf_overview/overview_page.html
+++ b/pdfding/pdf/templates/includes/pdf_overview/overview_page.html
@@ -1,7 +1,7 @@
 <div {% if layout == 'Grid' %}
-     class="grid grid-cols-1 min-[1200px]:grid-cols-2 min-[1600px]:grid-cols-3 gap-5 pb-8"
+     class="grid grid-cols-1 min-[1200px]:grid-cols-2 min-[1600px]:grid-cols-3 gap-5 pb-5"
      {% else %}
-     class="flex flex-col gap-y-5 pb-8"
+     class="flex flex-col gap-y-5 pb-5"
      {% endif %}
 >
     {% for pdf in page_obj %}
@@ -12,7 +12,7 @@
          class="relative border rounded-md bg-slate-100 border-slate-300 hover:border-slate-400
                 dark:bg-slate-800 dark:border-slate-700 dark:hover:border-slate-600
                 creme:bg-creme-dark-light creme:border-creme-dark creme:hover:border-stone-400">
-        <div class="px-3 md:px-5 py-1">
+        <div class="px-3 py-1">
             {% if layout == 'Compact' %}
             {% include 'includes/pdf_overview/compact_pdf.html' %}
             {% else %}
@@ -20,8 +20,8 @@
             {% endif %}
         </div>
         {% include 'includes/pdf_overview/pdf_actions_menu.html' %}
-        {% if pdf.number_of_pages > 0 %}
-        <div class="hover:cursor-pointer pt-1 -mt-1!" x-data="{ tooltip_progress: false }" id="progressbar-{{ loop_id }}">
+        {% if request.user.profile.show_progress_bars == 'Enabled' and pdf.number_of_pages > 0 %}
+        <div class="hover:cursor-pointer -mt-1!" x-data="{ tooltip_progress: false }" id="progressbar-{{ loop_id }}">
                 <div x-on:mouseenter="tooltip_progress = true" x-on:mouseleave="tooltip_progress = false"
                      class="w-full h-1 rounded-sm">
                     <div style="width: {{ pdf.progress }}%;" class="h-1 bg-primary! rounded-sm"></div>

--- a/pdfding/pdf/templates/includes/pdf_overview/search_filters.html
+++ b/pdfding/pdf/templates/includes/pdf_overview/search_filters.html
@@ -1,4 +1,4 @@
-<div class="flex flex-wrap gap-x-2 -mb-1!">
+<div class="flex flex-wrap gap-x-2 pb-1 md:pb-2">
     <div class="flex items-center text-slate-500 dark:text-slate-300 creme:text-stone-600 text-sm">
         <span>Filters</span>
     </div>

--- a/pdfding/pdf/templates/includes/pdf_overview/spacious_pdf.html
+++ b/pdfding/pdf/templates/includes/pdf_overview/spacious_pdf.html
@@ -1,6 +1,6 @@
 <div  x-data="{ show_notes_{{ loop_id }}: false }">
-    <div class="flex flex-row -ml-2! md:-ml-3! pt-1 min-h-38" x-data="{ tooltip_date: false }">
-        <div id="thumbnail-{{ loop_id }}" class="pb-1 [&>div]:cursor-pointer"
+    <div class="flex flex-row pt-1 pb-0 min-h-36" x-data="{ tooltip_date: false }">
+        <div id="thumbnail-{{ loop_id }}" class="[&>div]:cursor-pointer"
              hx-get="{% url 'show_preview' pdf.id %}"
              hx-target="#preview"
              hx-swap="innerHTML"
@@ -11,7 +11,7 @@
                    src="{% url 'serve_thumbnail' pdf.id %}"/>
             </div>
             {% else %}
-            <div class="flex items-center justify-center !rounded-md border-[1px] w-26! h-36!
+            <div class="flex items-center justify-center !rounded-md border-[1px] w-26! h-34!
                         border-slate-200 !bg-slate-100 text-slate-700
                         dark:border-slate-600 dark:!bg-slate-700 dark:text-slate-200
                         creme:border-stone-400 creme:!bg-creme-light creme:text-stone-400">
@@ -24,7 +24,7 @@
             </div>
             {% endif %}
         </div>
-        <div class="truncate w-full flex flex-col pl-3 md:pl-8 text-sm text-slate-700 dark:text-slate-300 creme:text-stone-700">
+        <div class="truncate w-full flex flex-col pl-3 md:pl-5 text-sm text-slate-700 dark:text-slate-300 creme:text-stone-700">
             <div class="flex flex-row justify-between relative -mb-1
                         text-slate-400 dark:text-slate-500 creme:text-stone-500">
                 <div>

--- a/pdfding/templates/includes/get_next_page.html
+++ b/pdfding/templates/includes/get_next_page.html
@@ -2,13 +2,13 @@
      x-data="{ in_progress: false }"
      class="flex justify-center items-center gap-x-1 font-semibold
             text-slate-500 dark:text-slate-400 creme:text-stone-500
-            [&>div>div]:flex [&>div>div]:flex-row [&>div>div]:items-center [&>div>div]:gap-x-1">
+            [&>div>div]:flex [&>div>div]:flex-row [&>div>div]:items-center [&>div>div]:gap-x-1 pt-2">
     {% if next_page_available %}
     <div id="next_page_{{ current_page }}_toggle">
         <div class="cursor-pointer hover:text-slate-900 dark:hover:text-slate-100 creme:hover:text-stone-700"
              x-show="!in_progress"
              @click="in_progress = true"
-             hx-get="{% url get_next_overview_page_name page=current_page|add:1 %}"
+             hx-get="{% url get_next_overview_page_name page=current_page|add:1 %}?{{ request.META.QUERY_STRING }}"
              hx-target="#next_page_{{ current_page }}"
              hx-swap="outerHTML">
             <a>Load More</a>

--- a/pdfding/users/migrations/0016_readd_show_progress_bars.py
+++ b/pdfding/users/migrations/0016_readd_show_progress_bars.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+from pdf.service import process_with_pypdfium
+
+
+def adjust_thumbnails(apps, schema_editor):
+    """Regenerate thumbnail images after changing thumbnail dimensions"""
+
+    pdf_model = apps.get_model("pdf", "Pdf")
+
+    for pdf_object in pdf_model.objects.all():
+        process_with_pypdfium(pdf_object, delete_existing_thumbnail_and_preview=True)
+
+
+def reverse_func(apps, schema_editor):  # pragma: no cover
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0015_add_pdf_overview_layouts'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='show_progress_bars',
+            field=models.CharField(
+                choices=[('Enabled', 'Enabled'), ('Disabled', 'Disabled')], default='Enabled', max_length=8
+            ),
+        ),
+        migrations.RunPython(adjust_thumbnails, reverse_func),
+    ]

--- a/pdfding/users/models.py
+++ b/pdfding/users/models.py
@@ -68,6 +68,7 @@ class Profile(models.Model):
     layout = models.CharField(choices=LayoutChoice.choices, max_length=7, default=LayoutChoice.COMPACT)
     pdf_inverted_mode = models.CharField(choices=EnabledChoice.choices, max_length=8, default=EnabledChoice.DISABLED)
     pdf_sorting = models.CharField(choices=PdfSortingChoice, max_length=15, default=PdfSortingChoice.NEWEST)
+    show_progress_bars = models.CharField(choices=EnabledChoice.choices, max_length=8, default=EnabledChoice.ENABLED)
     shared_pdf_sorting = models.CharField(
         choices=SharedPdfSortingChoice, max_length=15, default=SharedPdfSortingChoice.NEWEST
     )

--- a/pdfding/users/templates/ui_settings.html
+++ b/pdfding/users/templates/ui_settings.html
@@ -74,6 +74,22 @@
                     </a>
                 </div>
             </div>
+            <div class="pt-6">
+                <span class="text-lg font-bold">Show Progress Bars</span>
+            </div>
+            <div class="flex justify-between text-slate-600 dark:text-slate-400 creme:text-stone-500">
+                <div class="w-5/6">
+                    <span id="show_progress_bars">{{ user.profile.show_progress_bars }}</span>
+                </div>
+                <div class="pr-6">
+                    <a id="show_progress_bars_edit" class="cursor-pointer text-primary hover:text-secondary"
+                        hx-get="{% url 'profile-setting-change' 'show_progress_bars' %}"
+                        hx-target="#show_progress_bars"
+                        hx-swap="innerHTML" >
+                        Edit
+                    </a>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/pdfding/users/tests/test_migrations.py
+++ b/pdfding/users/tests/test_migrations.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from pdf.models import Pdf
 
 add_pdf_overview_layouts = importlib.import_module('users.migrations.0015_add_pdf_overview_layouts')
+readd_show_progress_bars = importlib.import_module('users.migrations.0016_readd_show_progress_bars')
 
 
 class TestMigrations(TestCase):
@@ -16,7 +17,7 @@ class TestMigrations(TestCase):
         self.user = User.objects.create_user(username='test_user', password='12345')
         self.pdf = Pdf.objects.create(owner=self.user.profile, name='pdf_1')
 
-    def test_fill_adjust_thumbnails(self):
+    def test_fill_adjust_thumbnails_0015(self):
         # as I cannot mock the migration file since it has an illegal name and applying the migration
         # in the test did not work either I am using a dummy pdf file -.-. The dummy file has two pages.
 
@@ -36,6 +37,30 @@ class TestMigrations(TestCase):
         self.assertTrue(pdf.thumbnail)
         self.assertTrue(pdf.preview)
 
-    def test_fill_adjust_thumbnails_exception_caught(self):
+    def test_fill_adjust_thumbnails_0015_exception_caught(self):
         self.assertEqual(self.pdf.number_of_pages, -1)
         add_pdf_overview_layouts.adjust_thumbnails(apps, connection.schema_editor())
+
+    def test_fill_adjust_thumbnails_0016(self):
+        # as I cannot mock the migration file since it has an illegal name and applying the migration
+        # in the test did not work either I am using a dummy pdf file -.-. The dummy file has two pages.
+
+        self.assertEqual(self.pdf.number_of_pages, -1)
+        self.assertFalse(self.pdf.thumbnail)
+        self.assertFalse(self.pdf.preview)
+
+        dummy_path = Path(__file__).parents[2] / 'pdf' / 'tests' / 'data' / 'dummy.pdf'
+        with dummy_path.open(mode="rb") as f:
+            self.pdf.file = File(f, name=dummy_path.name)
+            self.pdf.save()
+
+        readd_show_progress_bars.adjust_thumbnails(apps, connection.schema_editor())
+
+        pdf = Pdf.objects.get(id=self.pdf.id)
+        self.assertEqual(pdf.number_of_pages, 2)
+        self.assertTrue(pdf.thumbnail)
+        self.assertTrue(pdf.preview)
+
+    def test_fill_adjust_thumbnails_0016_exception_caught(self):
+        self.assertEqual(self.pdf.number_of_pages, -1)
+        readd_show_progress_bars.adjust_thumbnails(apps, connection.schema_editor())

--- a/pdfding/users/tests/test_views.py
+++ b/pdfding/users/tests/test_views.py
@@ -89,19 +89,14 @@ class TestProfileViews(TestCase):
 
         headers = {'HTTP_HX-Request': 'true'}
 
-        field_names = [
-            'pdf_inverted_mode',
-            'custom_theme_color',
-            'theme',
-            'theme_color',
-            'email',
-        ]
+        field_names = ['pdf_inverted_mode', 'custom_theme_color', 'theme', 'theme_color', 'email', 'show_progress_bars']
         form_list = [
             forms.GenericUserFieldForm,
             forms.CustomThemeColorForm,
             forms.GenericUserFieldForm,
             forms.GenericUserFieldForm,
             forms.EmailForm,
+            forms.GenericUserFieldForm,
         ]
         initial_dicts = [
             {'pdf_inverted_mode': 'Disabled'},
@@ -109,6 +104,7 @@ class TestProfileViews(TestCase):
             {'dark_mode': 'Light'},
             {'theme_color': 'Green'},
             {'email': 'a@a.com'},
+            {'show_progress_bars': 'Enabled'},
         ]
 
         for field_name, form, initial_dict in zip(field_names, form_list, initial_dicts):
@@ -192,9 +188,9 @@ class TestProfileViews(TestCase):
 
     def test_change_settings_normal_post_correct(self):
         for field_name, val_before, val_after in zip(
-            ['pdf_inverted_mode'],
-            ['Disabled'],
-            ['Enabled'],
+            ['pdf_inverted_mode', 'show_progress_bars'],
+            ['Disabled', 'Enabled'],
+            ['Enabled', 'Disabled'],
         ):
             self.assertEqual(getattr(self.user.profile, field_name), val_before)
             self.client.post(

--- a/pdfding/users/views.py
+++ b/pdfding/users/views.py
@@ -53,6 +53,7 @@ class ChangeSetting(View):
         'theme_color': forms.create_user_field_form(['theme_color']),
         'pdf_inverted_mode': forms.create_user_field_form(['pdf_inverted_mode']),
         'custom_theme_color': forms.CustomThemeColorForm,
+        'show_progress_bars': forms.create_user_field_form(['show_progress_bars']),
     }
 
     def get(self, request: HttpRequest, field_name: str):
@@ -64,6 +65,7 @@ class ChangeSetting(View):
             'theme_color': {'theme_color': request.user.profile.theme_color},
             'custom_theme_color': {'custom_theme_color': request.user.profile.custom_theme_color},
             'pdf_inverted_mode': {'pdf_inverted_mode': request.user.profile.pdf_inverted_mode},
+            'show_progress_bars': {'show_progress_bars': request.user.profile.show_progress_bars},
         }
 
         if request.htmx:


### PR DESCRIPTION
* fix loading next page, previously the layout and search filters were ignored.
* minor pdf overview ui improvements
* adjust bottom spacing of search filters
* add setting to disable progress bars