### PR TITLE
fix: allow overriding data directory

### DIFF
--- a/pdfding/backup/tests/test_tasks.py
+++ b/pdfding/backup/tests/test_tasks.py
@@ -135,8 +135,8 @@ class TestSqliteBackup(TestCase):
                 pdf.tags.set(tags)
 
     def test_backup_sqlite(self):
-        test_db_path = settings.BASE_DIR / 'db' / 'test.sqlite3'
-        backup_db_path = settings.BASE_DIR / 'db' / 'test_backup.sqlite3'
+        test_db_path = settings.DATA_DIR / 'db' / 'test.sqlite3'
+        backup_db_path = settings.DATA_DIR / 'db' / 'test_backup.sqlite3'
 
         tasks.backup_sqlite(test_db_path, backup_db_path)
 

--- a/pdfding/core/settings/base.py
+++ b/pdfding/core/settings/base.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parents[2]
+DATA_DIR = Path(environ.get("DATA_DIR", BASE_DIR))
 
 
 # Quick-start development settings - unsuitable for production
@@ -111,10 +112,10 @@ else:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': BASE_DIR / 'db' / 'db.sqlite3',
-            'BACKUP_NAME': BASE_DIR / 'db' / 'backup.sqlite3',
+            'NAME': DATA_DIR / 'db' / 'db.sqlite3',
+            'BACKUP_NAME': DATA_DIR / 'db' / 'backup.sqlite3',
             'TEST': {
-                'NAME': BASE_DIR / 'db' / 'test.sqlite3',
+                'NAME': DATA_DIR / 'db' / 'test.sqlite3',
             },
         }
     }
@@ -159,7 +160,7 @@ STATICFILES_DIRS = [BASE_DIR / 'static']
 STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 MEDIA_URL = '/media/'
-MEDIA_ROOT = BASE_DIR / 'media'
+MEDIA_ROOT = DATA_DIR / 'media'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
@@ -187,7 +188,7 @@ SOCIALACCOUNT_OPENID_CONNECT_URL_PREFIX = ''
 # Huey task queue
 HUEY = {
     'huey_class': 'huey.SqliteHuey',
-    'filename': BASE_DIR / 'db' / 'tasks.sqlite3',
+    'filename': DATA_DIR / 'db' / 'tasks.sqlite3',
     'immediate': False,  # settings.DEBUG,  # If DEBUG=True, run synchronously.
     'results': False,  # Store return values of tasks.
     'store_none': False,  # If a task returns None, do not save to results.
@@ -205,7 +206,7 @@ HUEY = {
     },
 }
 
-CONSUME_DIR = BASE_DIR / 'consume'
+CONSUME_DIR = DATA_DIR / 'consume'
 
 log_level = environ.get('LOG_LEVEL', 'ERROR')
 

--- a/pdfding/users/management/commands/clean_up.py
+++ b/pdfding/users/management/commands/clean_up.py
@@ -32,8 +32,8 @@ def clean_up_deleted_shared_pdfs():
 
 
 def clean_demo_db(
-    db_path: Path = settings.BASE_DIR / 'db' / 'db.sqlite3',
-    after_migration_db_path: Path = settings.BASE_DIR / 'db' / 'migrated.sqlite3',
+    db_path: Path = settings.DATA_DIR / 'db' / 'db.sqlite3',
+    after_migration_db_path: Path = settings.DATA_DIR / 'db' / 'migrated.sqlite3',
 ):
     """Clean the database for the demo mode. In this state the db will have applied migrations but no users or pdfs."""
 


### PR DESCRIPTION
This allows setting a DATA_DIR enviroment variable from the outside, so the user can choose to set it to `/var/lib/pdfding` for eg.
It defaults to BASE_DIR so it should work like it did before if not set.

---

Also just wanted to let you know I am packaging this project for the nixos/nixpkgs ecosystem, if you are interested here's the tracking link for it, https://github.com/ngi-nix/ngipkgs/issues/1719