### PR TITLE
Make gunicorn worker timeout configurable via new ENV var.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,4 +25,5 @@ HOST_PORT="${HOST_PORT:-8000}"
 python manage.py migrate
 python manage.py clean_up
 
-exec python -m gunicorn --bind 0.0.0.0:$HOST_PORT --workers 3 core.wsgi:application
+WORKER_TIMEOUT="${WORKER_TIMEOUT:-30}"
+exec python -m gunicorn --bind 0.0.0.0:$HOST_PORT --workers 3 --timeout $WORKER_TIMEOUT core.wsgi:application


### PR DESCRIPTION
File uploads that exceed the standard 30 second timeout result fail.

This commit makes the gunicorn worker timeout configurable via a new ENV var: WORKER_TIMEOUT, which defaults to gunicorn's 30 second default.

While I was not able to reproduce a 30+ second timeout locally, I can confirm that setting the var to 2 seconds + uploading a very large file does trigger the server error. Setting the var to, say, 60 seconds allows the upload to complete without problems.