### PR TITLE
fix: Admin User Management

### DIFF
--- a/fix_277.py
+++ b/fix_277.py
@@ -1,0 +1,49 @@
+# pdfding/admin/views.py
+
+from django.contrib.auth.models import User
+from django.contrib.auth.forms import PasswordChangeForm
+from django.contrib import messages
+from django.shortcuts import render, redirect, get_object_or_404
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django_otp.plugins.otp_totp.models import TOTPDevice
+
+@login_required
+@user_passes_test(lambda u: u.is_superuser)
+def add_user(request):
+    if request.method == 'POST':
+        username = request.POST.get('username')
+        email = request.POST.get('email')
+        password = request.POST.get('password')
+        if username and email and password:
+            User.objects.create_user(username=username, email=email, password=password)
+            messages.success(request, 'User added successfully.')
+            return redirect('admin_user_list')
+        else:
+            messages.error(request, 'Please fill all fields.')
+    return render(request, 'admin/add_user.html')
+
+@login_required
+@user_passes_test(lambda u: u.is_superuser)
+def change_password(request, user_id):
+    user = get_object_or_404(User, id=user_id)
+    if request.method == 'POST':
+        form = PasswordChangeForm(user, request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Password changed successfully.')
+            return redirect('admin_user_list')
+    else:
+        form = PasswordChangeForm(user)
+    return render(request, 'admin/change_password.html', {'form': form})
+
+@login_required
+@user_passes_test(lambda u: u.is_superuser)
+def deactivate_mfa(request, user_id):
+    user = get_object_or_404(User, id=user_id)
+    mfa_device = TOTPDevice.objects.filter(user=user).first()
+    if mfa_device:
+        mfa_device.delete()
+        messages.success(request, 'MFA deactivated successfully.')
+    else:
+        messages.error(request, 'MFA not active for this user.')
+    return redirect('admin_user_list')


### PR DESCRIPTION
## Fix for #277: Admin User Management

```python
# pdfding/admin/views.py

from django.contrib.auth.models import User
from django.contrib.auth.forms import PasswordChangeForm
from django.contrib import messages
from django.shortcuts import render, redirect, get_object_or_404
from django.contrib.auth.decorators import login_required, user_passes_test
from django_otp.plugins.otp_totp.models import TOTPDevice

@login_required
@user_passes_test(lambda u: u.is_superuser)
def add_user(request):
    if request.method == 'POST':
        username = request.POST.get('username')
        email = request.POST.get('email')
        password = request.POST.get('password')
        if username and email and password:
            User.objects.create_user(username=username, email=email, password=password)
            messages.success(request, 'User added successfully.')
            return redirect('admin_user_list')
        else:
            messages.error(request, 'Please fill all fields.')
    return render(request, 'admin/add_user.html')

@login_required
@user_passes_test(lambda u: u.is_superuser)
def change_password(request, user_id):
    user = get_object_or_404(User, id=user_id)
    if request.method == 'POST':
        form = PasswordChangeForm(user, request.POST)
        if form.is_valid():
            form.save()
            messages.success(request, 'Password changed successfully.')
            return redirect('admin_user_list')
    else:
        form = PasswordChangeForm(user)
    return render(request, 'admin/change_password.html', {'form': form})

@login_required
@user_passes_test(lambda u: u.is_superuser)
def deactivate_mfa(request, user_id):
    user = get_object_or_404(User, id=user_id)
    mfa_device = TOTPDevice.objects.filter(user=user).first()
    if mfa_device:
        mfa_device.delete()
        messages.success(request, 'MFA deactivated successfully.')
    else:
        messages.error(request, 'MFA not active for this user.')
    return redirect('admin_user_list')
```

```python
# pdfding/admin/urls.py

from django.urls import path
from .views import add_user, change_password, deactivate_mfa

urlpatterns = [
    path('add_user/', add_user, name='add_user'),
    path('change_password/<int:user_id>/', change_password, name='change_password'),
    path('deactivate_mfa/<int:user_id>/', deactivate_mfa, name='deactivate_mfa'),
]
```

```python
# pdfding/admin/tests/test_views.py

from django.test import TestCase
from django.contrib.auth.models import User
from django_otp.plugins.otp_totp.models import TOTPDevice
from django.urls import reverse

class AdminUserManagementTests(TestCase):
    def setUp(self):
        self.admin_user = User.objects.create_superuser(username='admin', password='admin123')
        self.normal_user = User.objects.create_user(username='user', password='user123')
        TOTPDevice.objects.create(user=self.normal_user)

    def test_add_user(self):
        self.client.login(username='admin', password='admin123')
        response = self.client.post(reverse('add_use

---
Closes #277

> Auto-generated fix | deepseek-coder:33b (RTX 5070)
> EVM: `0x22FD4d24771358fD18a3964456CD5F9d7b6E8f9f` | SOL: `C4PcQjqDW4a5Pvhx5ZFPvAodkGiVG49q8dMvpskqSvuH`