### PR TITLE
fix: Do not create duplicates when saving PDFs in the viewer

### DIFF
--- a/pdfding/pdf/tests/test_views/test_pdf_views.py
+++ b/pdfding/pdf/tests/test_views/test_pdf_views.py
@@ -18,6 +18,8 @@ from pdf.services.workspace_services import create_collection, create_workspace
 from pdf.views import pdf_views
 from users.service import get_demo_pdf
 
+from pdfding.core.settings.base import MEDIA_ROOT
+
 DEMO_FILE_SIZE = 29451
 
 
@@ -718,6 +720,9 @@ class TestViews(TestCase):
             pdf.file = file
             pdf.save()
 
+        original_file_name = pdf.file.name
+        original_file_path = MEDIA_ROOT / original_file_name
+
         self.assertEqual(pdf.file.size, 0)
         self.assertEqual(pdf.revision, 0)
 
@@ -732,6 +737,8 @@ class TestViews(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(pdf.file.size, 8885)
         self.assertEqual(pdf.revision, 1)
+        self.assertEqual(pdf.file.name, original_file_name)
+        self.assertTrue(original_file_path.exists())
         mock_set_highlights_and_comments.assert_called_once_with(pdf)
 
     @mock.patch('pdf.views.pdf_views.PdfProcessingServices.set_highlights_and_comments')

--- a/pdfding/pdf/views/pdf_views.py
+++ b/pdfding/pdf/views/pdf_views.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 from base import base_views
+from core.settings import MEDIA_ROOT
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_not_required
@@ -571,11 +572,27 @@ class UpdatePdf(PdfMixin, View):
         else:
             updated_pdf = request.FILES.get('updated_pdf')
         try:
+            old_file_name = pdf.file.name
+            old_file_path = MEDIA_ROOT / old_file_name
+
             # make sure a valid pdf is sent
             updated_pdf = forms.CleanHelpers.clean_file(updated_pdf)
             pdf.file = updated_pdf
             pdf.revision += 1
             pdf.save()
+
+            # adjust file name, django adds a suffix changing the file
+            # we want to keep the original file name though.
+            try:
+                old_file_path.unlink()
+            except FileNotFoundError:  # pragma: no cover
+                pass
+
+            new_file_path = MEDIA_ROOT / pdf.file.name
+            pdf.file.name = old_file_name
+            pdf.save()
+
+            new_file_path.rename(old_file_path)
 
             PdfProcessingServices.set_highlights_and_comments(pdf)
 


### PR DESCRIPTION
closes #287